### PR TITLE
Small fix to league and season specs

### DIFF
--- a/spec/league_spec.rb
+++ b/spec/league_spec.rb
@@ -2,7 +2,7 @@ require './spec_helper'
 
 RSpec.describe League do
   before(:each) do
-    games_path = './data_dummy/games_dummy.csv'
+    game_path = './data_dummy/games_dummy.csv'
     games_data = CSV.read(game_path, headers: true, header_converters: :symbol)
     @league = League.new(games_data)
 

--- a/spec/season_spec.rb
+++ b/spec/season_spec.rb
@@ -2,7 +2,7 @@ require './spec_helper'
 
 RSpec.describe Season do
   before(:each) do
-    games_path = './data_dummy/games_dummy.csv'
+    game_path = './data_dummy/games_dummy.csv'
     games_data = CSV.read(game_path, headers: true, header_converters: :symbol)
     @season = League.new(games_data)
 


### PR DESCRIPTION
removes the s from "games_path" in the variables in before:each blocks of season and league spec. 